### PR TITLE
DNS reverse lookup flag

### DIFF
--- a/output.c
+++ b/output.c
@@ -15,7 +15,6 @@
 #include "output.h"
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
 #include <stdlib.h>
 #include <string.h>
 #include <arpa/inet.h>
@@ -23,7 +22,6 @@
 
 #define BUF_SIZE 1024
 
-void report_server_rtt(struct in_addr client, struct in_addr server, uint16_t sport, uint16_t dport, int rtt);
 void reverse_dns_lookup(char * ip_addr, char * buffer);
 int exec_cmd(char * cmd, char ** args, char * buffer);
 
@@ -53,6 +51,7 @@ void reverse_dns_lookup(char * ip_addr, char * buffer){
   struct sockaddr_in sa;
   char node[NI_MAXHOST];
   int res;
+
   sa.sin_family = AF_INET;
   inet_pton(AF_INET, ip_addr, &sa.sin_addr);
 

--- a/output.h
+++ b/output.h
@@ -18,6 +18,6 @@
 #include <pcap/pcap.h>
 #include <arpa/inet.h>
 
-void report_server_rtt(struct in_addr client, struct in_addr server, u_short sport, u_short dport, int rtt);
+void report_server_rtt(struct in_addr client, struct in_addr server, uint16_t sport, uint16_t dport, int rtt);
 
 #endif

--- a/output.h
+++ b/output.h
@@ -18,6 +18,6 @@
 #include <pcap/pcap.h>
 #include <arpa/inet.h>
 
-void report_server_rtt(struct in_addr client, struct in_addr server, uint16_t sport, uint16_t dport, int rtt);
+void report_server_rtt(struct in_addr client, struct in_addr server, uint16_t sport, uint16_t dport, int rtt, int reverse_lookup);
 
 #endif

--- a/session.c
+++ b/session.c
@@ -14,6 +14,7 @@
  */
 #include "session.h"
 #include "output.h"
+#include "options.h"
 
 #include <stdlib.h>
 
@@ -108,9 +109,8 @@ void find_in_syn(const struct sniff_ip* ip, const struct sniff_tcp* tcp, struct 
                 sess2->sport == sess1->dport &&
                 sess2->dport == sess1->sport) {
             /* Match found, calculate delta */
-           /*  delta = (sess2->ts.tv_usec - sess1->ts.tv_usec)/1000; */
-               delta = calc_delta(sess1->ts, sess2->ts);
-            report_server_rtt(sess1->ip_src, sess1->ip_dst, sess1->sport, sess1->dport, delta);
+            delta = calc_delta(sess1->ts, sess2->ts);
+            report_server_rtt(sess1->ip_src, sess1->ip_dst, sess1->sport, sess1->dport, delta, reverse_dns_flag);
 
             /* Free the memory allocated and clear the space in the array to 
              * prevent double freeing memory later */
@@ -148,7 +148,7 @@ void find_in_ack(const struct sniff_ip* ip, const struct sniff_tcp* tcp, struct 
                 sess2->dport == sess1->sport) {
             /* Match found, calculate delta */
             delta = calc_delta(sess1->ts, sess2->ts);
-            report_server_rtt(sess1->ip_src, sess1->ip_dst, sess1->sport, sess1->dport, delta);
+            report_server_rtt(sess1->ip_src, sess1->ip_dst, sess1->sport, sess1->dport, delta, reverse_dns_flag);
 
             /* Free the memory allocated and clear the space in the array to 
              * prevent double freeing memory later */

--- a/test.sh
+++ b/test.sh
@@ -29,5 +29,8 @@ wait
 
 ./sniffle -f /tmp/foo.pcap
 
+echo Testing reverse DNS lookup
+./sniffle -nf /tmp/foo.pcap
+
 rm /tmp/foo.pcap
 


### PR DESCRIPTION
I suspect, though I have no evidence to prove this, that this flag will slow down live capture considerably, because every matched packet will cause two DNS queries, which means four DNS queries for every tcp connection. It might be best to only use this on pcap files where we won't drop packets waiting for one to be processed.

All that being said, the reverse dns flag works now.